### PR TITLE
Updated composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "email": "keith@kmfk.io"
     },
     "require":     {
-        "php":                      ">=5.3.0",
+        "php":                      ">=5.3.3",
         "keen-io/keen-io":          "~2.1",
         "symfony/framework-bundle": "~2.3"
     },


### PR DESCRIPTION
A bundle can be only used in Symfony, which have minimal requirements on PHP: https://github.com/symfony/symfony/blob/2.7/composer.json#L19