### PR TITLE
Improve the CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,33 @@
 language: php
 
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 php:
   - 5.3
+  - 5.4
+  # 5.5 and 5.6 are already covered by the jobs running against specific Symfony versions. no need to duplicate them here
+  - 7.0
+  - hhvm
 
-env:
-    - SYMFONY_VERSION=2.3.*
-    - SYMFONY_VERSION=2.4.*
-    - SYMFONY_VERSION=2.5.*
+matrix:
+  include:
+    # force testing against Symfony LTS versions
+    - php: 5.5
+      env: SYMFONY_VERSION=2.3.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.7.*
+    # Test against lowest dependencies
+    - php: 5.6
+      env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
 
-before_script:
-    - composer self-update
-    - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
-    - composer install --dev --prefer-source
+before_install:
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi
+
+install:
+  - composer update $COMPOSER_FLAGS
 
 script: phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "symfony/framework-bundle": "~2.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~3.7"
+        "symfony/phpunit-bridge": "~2.7",
+        "phpunit/phpunit": "~4.5"
     },
     "autoload": {
         "psr-4": {

--- a/tests/DependencyInjection/KeenIOExtensionTest.php
+++ b/tests/DependencyInjection/KeenIOExtensionTest.php
@@ -6,13 +6,10 @@ use KeenIO\Bundle\KeenIOBundle\DependencyInjection\KeenIOExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class KeenIOExtensionTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * QPush Extension
-     *
      * @var KeenIOExtension
      */
     private $extension;


### PR DESCRIPTION
### Travis configuration improvements

- use the faster container-based infrastructure
- persist the composer download cache between builds as it is available in the new infrastructure
- test against more PHP versions than just PHP 5.3
- test against unmodified requirements to be sure they are enough to run the tests
- test against lowest dependencies to ensure lowest bounds are valid
- test against the Symfony LTS versions to ensure their support

### Test suite improvements

- use a maintained version of phpunit instead of the old PHP 3.7 one in the dev requirements (btw, you are not using it at all on Travis but are using the phar installed on Travis instead, is it intended ?)
- bring the symfony/phpunit-bridge package to make the testsuite fail when using deprecated APIs