### PR TITLE
Add support for Symfony 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,16 @@ php:
   - 5.4
   # 5.5 and 5.6 are already covered by the jobs running against specific Symfony versions. no need to duplicate them here
   - 7.0
+  - 7.1
   - hhvm
 
 matrix:
   include:
     # force testing against Symfony LTS versions
     - php: 5.5
-      env: SYMFONY_VERSION=2.3.*
-    - php: 5.6
       env: SYMFONY_VERSION=2.7.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8.*
     # Test against lowest dependencies
     - php: 5.6
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,13 @@
     "require":     {
         "php":                      ">=5.3.3",
         "keen-io/keen-io":          "~2.1",
-        "symfony/framework-bundle": "~2.3"
+        "symfony/config": "~2.3 || ~3.0",
+        "symfony/dependency-injection": "~2.3 || ~3.0",
+        "symfony/http-kernel": "~2.3 || ~3.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "~2.7",
+        "symfony/phpunit-bridge": "~3.2",
+        "symfony/yaml": "~2.3 || ~3.0",
         "phpunit/phpunit": "~4.5"
     },
     "autoload": {


### PR DESCRIPTION
This also replaces the dependency on symfony/framework-bundle (which is not actually needed) by requirements on the actual dependencies (instead of relying on the fact that FrameworkBundle also requires them).