### PR TITLE
Make the configuration of the version more user-friendly

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,6 +14,11 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('version')
+                    ->beforeNormalization()
+                        // force the version to be a string, even if the Yaml config files parsed it as float
+                        ->ifTrue(function ($v) { return !is_string($v) && is_numeric($v); })
+                        ->then(function ($v) { return number_format($v, 1); })
+                    ->end()
                     ->defaultValue('3.0')
                     ->info('The Keen IO API Version')
                     ->example('3.0')

--- a/tests/DependencyInjection/KeenIOExtensionTest.php
+++ b/tests/DependencyInjection/KeenIOExtensionTest.php
@@ -37,5 +37,6 @@ class KeenIOExtensionTest extends \PHPUnit_Framework_TestCase
         $this->container->compile();
 
         $this->assertTrue($this->container->has('keen_io'));
+        $this->assertInstanceOf('KeenIO\Client\KeenIOClient', $this->container->get('keen_io'));
     }
 }


### PR DESCRIPTION
The client expects the version to be a string '3.0'. This change allows to configure the version as a float by formatting it properly, to make it possible to use the unquoted syntax in Yaml, which will produce a float.
Note that the config file in the test fixtures was already using a float, but the tests were not failing because the service was not instantiated.