### PR TITLE
Add support for autowiring in Symfony 3.3+

### DIFF
--- a/src/DependencyInjection/KeenIOExtension.php
+++ b/src/DependencyInjection/KeenIOExtension.php
@@ -2,6 +2,7 @@
 
 namespace KeenIO\Bundle\KeenIOBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -35,5 +36,8 @@ class KeenIOExtension extends Extension
         }
 
         $container->setDefinition('keen_io', $definition);
+
+        // Support autowiring in Symfony 3.3+
+        $container->setAlias('KeenIO\Client\KeenIOClient', new Alias('keen_io', false));
     }
 }


### PR DESCRIPTION
A private alias for the KeenIO\Client\KeenIOClient class pointing to the keen_io service is registered, to make it available for the new autowiring system.