### PR TITLE
Add full deprecation reporting in the testsuite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "symfony/http-kernel": "^3.4.26 || ^4.3"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^4.4",
+        "symfony/phpunit-bridge": "^5.0.5",
+        "symfony/error-handler": "^4.4.5 || ^5.0.5",
         "symfony/yaml": "^3.4.26 || ^4.3",
         "phpunit/phpunit": "^8.5.2 || ^9.0.1"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,4 +27,8 @@
         <log type="coverage-text" target="php://stdout" />
         <log type="coverage-html" target="coverage/" />
     </logging>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>


### PR DESCRIPTION
Deprecations triggered when extending a deprecated parent class or implementing a deprecated interface are handled by the DebugClassLoader. The phpunit-bridge takes care of registering it if it is installed, so we need to install it.