### PR TITLE
Remove usage of the deprecated base extension from HttpKernel

### DIFF
--- a/src/DependencyInjection/KeenIOExtension.php
+++ b/src/DependencyInjection/KeenIOExtension.php
@@ -3,9 +3,9 @@
 namespace KeenIO\Bundle\KeenIOBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Alias;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 /**
  * @final


### PR DESCRIPTION
The base extension available in HttpKernel only adds support for registering some classes to be added in the cache warmer of the doctrine/annotations parser, compared to the base class of the DI component.
As annotations are not supported anymore in Symfony 7, this base class has been deprecated in Symfony 7.1.
As this bundle does not rely on the extra feature, it can use the base class from DI directly.